### PR TITLE
Updates after transferring repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -214,12 +214,12 @@
       }
     },
     "debug": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
-      "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
-        "ms": "0.7.2"
+        "ms": "2.0.0"
       }
     },
     "deep-is": {
@@ -715,9 +715,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -875,9 +875,9 @@
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Internal ESLint plugin for Routable",
   "keywords": [
     "eslint",
@@ -8,9 +8,9 @@
     "eslint-plugin"
   ],
   "author": "Emily Kolar <emkolar@gmail.com>",
-  "repository": "https://github.com/sheminusminus/eslint-plugin-routable.git",
-  "bugs": "https://github.com/sheminusminus/eslint-plugin-routable/issues",
-  "homepage": "https://www.npmjs.com/package/eslint-plugin-routable",
+  "repository": "https://github.com/warrenpay/eslint-plugin-routable",
+  "bugs": "https://github.com/warrenpay/eslint-plugin-routable/issues",
+  "homepage": "https://github.com/warrenpay/eslint-plugin-routable",
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha tests --recursive lib/tests/rules"


### PR DESCRIPTION
Update all the `package.json` urls, bump patch version (since 1.0.1 would _technically_ point at the old repo url), and ran `npm audit fix` for patchable non-breaking changes.
