### PR TITLE
Bug fix and patch-version bump

### DIFF
--- a/lib/rules/default-props-prefer-undefined.js
+++ b/lib/rules/default-props-prefer-undefined.js
@@ -156,7 +156,7 @@ module.exports = {
 
       for (
         let i = 0, len = expectations.length;
-        errorMessageId === undefined, i < len; // break the loop on first issue found
+        errorMessageId === undefined && i < len; // break the loop on first issue found
         i += 1
       ) {
         const { value, isOn } = expectations[i];

--- a/lib/rules/exports-newlines.js
+++ b/lib/rules/exports-newlines.js
@@ -94,9 +94,8 @@ module.exports = {
       const lineDifference = getLineDifference(node, nextNode);
 
       const countIsLow = lineDifference < EXPECTED_LINE_DIFFERENCE;
-      const countIsHigh = lineDifference > EXPECTED_LINE_DIFFERENCE;
 
-      if (countIsLow || countIsHigh) {
+      if (countIsLow) {
         let column = node.loc.start.column;
 
         if (node.loc.start.line !== node.loc.end.line) {

--- a/lib/tests/rules/default-props-prefer-undefined.js
+++ b/lib/tests/rules/default-props-prefer-undefined.js
@@ -17,6 +17,8 @@ const rule = require('../../rules/default-props-prefer-undefined');
 
 const ERR_MSG_EXPECTED_NOT_NULL = 'Expected default prop someProp to be undefined but is null';
 const ERR_MSG_EXPECTED_NOT_FALSE = 'Expected default prop someProp to be undefined but is false';
+const ERR_MSG_MULTI_EXPECTED_NOT_NULL = 'Expected default prop anotherProp to be undefined but is null';
+const ERR_MSG_MULTI_EXPECTED_NOT_FALSE = 'Expected default prop otherProp to be undefined but is false';
 
 //------------------------------------------------------------------------------
 // Tests
@@ -487,6 +489,42 @@ errors: [{
         line: 9,
         column: 11,
         message: ERR_MSG_EXPECTED_NOT_FALSE,
+      }],
+    },
+    // check that every default prop with issue fires a report
+    {
+      code: `
+        const SomeComponent = (props) => {
+          return <div />;
+        };
+        SomeComponent.propTypes = {
+          someProp: PropTypes.string,
+          otherProp: PropTypes.bool,
+          anotherProp: PropTypes.number,
+          lastProp: PropTypes.shape({}),
+        };
+        SomeComponent.defaultProps = {
+          someProp: null,
+          otherProp: false,
+          anotherProp: null,
+          lastProp: undefined,
+        };
+      `,
+      options: [{
+        forbidFalse: true,
+      }],
+      errors: [{
+        line: 12,
+        column: 11,
+        message: ERR_MSG_EXPECTED_NOT_NULL,
+      }, {
+        line: 13,
+        column: 11,
+        message: ERR_MSG_MULTI_EXPECTED_NOT_FALSE,
+      }, {
+        line: 14,
+        column: 11,
+        message: ERR_MSG_MULTI_EXPECTED_NOT_NULL,
       }],
     },
   ],

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -8,6 +8,7 @@
  * @property {*[]} decorators
  * @property {Object} loc
  * @property {ASTNode} parent
+ * @property {number[]} range
  * @property {string} type
  * @property {ASTNode|BuiltInType} value
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Internal ESLint plugin for Routable",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-routable",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Internal ESLint plugin for Routable",
   "keywords": [
     "eslint",


### PR DESCRIPTION
# summary

working with this rule in practice, there were two cases my rule tests did NOT cover that needed updates.

one of them-- handling when the empty line count is too high-- is just removed for now. I wanted to handle both low and high, but high counts are a much longer story, because we're deleting code, which becomes problematic as lines with comments are special case and will take a while to get right.

the second is-- handling when a single component has multiple default props defined incorrectly.
this fixes multiple errors cases, and adds tests that cover them.

also bumps version to 1.1.1 for these fixes.

# screenshots

<img width="638" alt="Screen Shot 2020-03-25 at 3 22 48 PM" src="https://user-images.githubusercontent.com/9907610/77591568-759f6780-6ead-11ea-80ee-27b14575676e.png">
<img width="651" alt="Screen Shot 2020-03-25 at 3 22 40 PM" src="https://user-images.githubusercontent.com/9907610/77591570-7637fe00-6ead-11ea-89ab-4c76eadabe17.png">
